### PR TITLE
Code cleanup

### DIFF
--- a/TopoAlign/PickFilters/TopoPickFilter.cs
+++ b/TopoAlign/PickFilters/TopoPickFilter.cs
@@ -13,11 +13,6 @@ public class TopoPickFilter : ISelectionFilter
         }
 
 #if REVIT2024_OR_GREATER
-        //if (elem.Category.Id.Value == (long)BuiltInCategory.OST_Topography)
-        //{
-        //    return true;
-        //}
-
         if (elem.Category.Id.Value == (int)BuiltInCategory.OST_Toposolid)
         {
             return true;

--- a/TopoAlign/Properties/launchSettings.json
+++ b/TopoAlign/Properties/launchSettings.json
@@ -1,5 +1,11 @@
 {
   "profiles": {
+    "Revit 2026": {
+      "commandName": "Executable",
+      "executablePath": "%ProgramW6432%\\Autodesk\\Revit 2026\\Revit.exe",
+      "commandLineArgs": "",
+      "use64Bit": true
+    },
     "Revit 2025": {
       "commandName": "Executable",
       "executablePath": "%ProgramW6432%\\Autodesk\\Revit 2025\\Revit.exe",

--- a/TopoAlign/TopoAlign.csproj
+++ b/TopoAlign/TopoAlign.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	  <Configurations>Debug R22;Debug R23;Debug R24;Debug R25;Debug R26</Configurations>
-	  <Configurations>$(Configurations)Release R22;Release R23;Release R24;Release R25;Release R26</Configurations>
+	  <Configurations>$(Configurations);Release R22;Release R23;Release R24;Release R25;Release R26</Configurations>
 	  <Description>Align topo surface to model elements</Description>
 	  <Copyright>Copyright © Russell Green</Copyright>
 	  <Version>2.6.0</Version>


### PR DESCRIPTION
#### PR Summary
This pull request removes unnecessary commented-out code and introduces a new profile for Revit 2026 in the launch settings. It also updates the project configuration to ensure proper listing of debug and release configurations.
- `TopoPickFilter.cs`: Removed commented-out code for `OST_Topography` check; retained check for `OST_Toposolid`.
- `launchSettings.json`: Added a new profile for "Revit 2026" with executable path and settings.
- `TopoAlign.csproj`: Updated `Configurations` property to append release configurations for various Revit versions.
