### PR TITLE
Refactor and add Revit version compatibility

### DIFF
--- a/TopoAlign/App.cs
+++ b/TopoAlign/App.cs
@@ -55,7 +55,11 @@ class App : IExternalApplication
             $"Align to{Environment.NewLine}Topo",
             Assembly.GetExecutingAssembly().Location,
             $"{nameof(TopoAlign)}.{nameof(Commands)}.{nameof(Commands.CommndAlignFloor)}"));
+#if REVIT2026_OR_GREATER
+        pbFloorAlign.ToolTip = "Delete the floor and place a toposolid sub-region";
+#else
         pbFloorAlign.ToolTip = "Adjust a floor to follow the topography";
+#endif
         pbFloorAlign.LargeImage = PngImageSource("TopoAlign.Images.FloorToTopo32.png");
 
         PushButton pbPointsFromLines = (PushButton)panel.AddItem(new PushButtonData(

--- a/TopoAlign/Comparers/XyEqualityComparer.cs
+++ b/TopoAlign/Comparers/XyEqualityComparer.cs
@@ -1,0 +1,27 @@
+﻿using Autodesk.Revit.DB;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TopoAlign.Helpers;
+
+namespace TopoAlign.Comparers;
+
+internal class XyEqualityComparer : IEqualityComparer<XYZ>
+{
+    private const double _sixteenthInchInFeet = 1.0d / (16.0d * 12.0d);
+
+    public bool Equals(XYZ p, XYZ q)
+    {
+        var testPoint = new XYZ(q.X, q.Y, p.Z);
+
+        return p.IsAlmostEqualTo(testPoint, _sixteenthInchInFeet);
+    }
+
+
+    public int GetHashCode(XYZ p)
+    {
+        return StringFormatting.PointString(p).GetHashCode();
+    }
+}

--- a/TopoAlign/Comparers/XyzEqualityComparer.cs
+++ b/TopoAlign/Comparers/XyzEqualityComparer.cs
@@ -4,7 +4,7 @@ using TopoAlign.Helpers;
 
 namespace TopoAlign.Comparers;
 
-class XyzEqualityComparer : IEqualityComparer<XYZ>
+internal class XyzEqualityComparer : IEqualityComparer<XYZ>
 {
     private const double _sixteenthInchInFeet = 1.0d / (16.0d * 12.0d);
 


### PR DESCRIPTION
Refactor and add Revit version compatibility

Refactored `CommndAlignFloor` to improve modularity and maintainability. Added conditional compilation to support multiple Revit versions, including `REVIT2026_OR_GREATER`. Introduced `ResetFloorSlape`, `CreateSubRegion`, and `CreateSubDivision` methods for better code organization.

Enhanced point handling with `XyEqualityComparer` for 2D de-duplication and improved `GetPointsFromSubDivision` logic to ensure edge and corner points are included. Updated `XyzEqualityComparer` to use `internal` access modifier.

Improved error handling in `CreateSubRegion` with user feedback for overlapping subregions. Removed unused code and ensured compatibility across Revit versions with version-specific API calls.