### PR TITLE
Added R2021 back as a supported version

### DIFF
--- a/Installer/TopoAlign.aip
+++ b/Installer/TopoAlign.aip
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<DOCUMENT Type="Advanced Installer" CreateVersion="19.1" version="23.5" Modules="simple" RootPath="." Language="en" Id="{5916C2D6-3FA4-4F34-99C8-C6302DB4726B}">
+<DOCUMENT Type="Advanced Installer" CreateVersion="19.1" version="23.6" Modules="simple" RootPath="." Language="en" Id="{5916C2D6-3FA4-4F34-99C8-C6302DB4726B}">
   <COMPONENT cid="caphyon.advinst.msicomp.MsiPropsComponent">
     <ROW Property="AI_BITMAP_DISPLAY_MODE" Value="0"/>
     <ROW Property="ALLUSERS" Value="1"/>
@@ -34,6 +34,7 @@
     <ROW Directory="__10_Dir" Directory_Parent="Contents_Dir" DefaultDir="2023"/>
     <ROW Directory="__1_Dir" Directory_Parent="Contents_Dir" DefaultDir="2025"/>
     <ROW Directory="__2_Dir" Directory_Parent="Contents_Dir" DefaultDir="2027"/>
+    <ROW Directory="__3_Dir" Directory_Parent="Contents_Dir" DefaultDir="2021"/>
     <ROW Directory="__9_Dir" Directory_Parent="Contents_Dir" DefaultDir="2022"/>
     <ROW Directory="__Dir" Directory_Parent="Contents_Dir" DefaultDir="2024"/>
   </COMPONENT>
@@ -44,12 +45,14 @@
     <ROW Component="ProductInformation" ComponentId="{0A801FF0-EE12-4064-A813-C0D2975DDD0A}" Directory_="APPDIR" Attributes="260" KeyPath="Version"/>
     <ROW Component="TopoAlign.addin" ComponentId="{DB3AEEB0-2CA7-4866-B25C-E4C972C29E5C}" Directory_="NewFolder_Dir" Attributes="0" KeyPath="TopoAlign.addin" Type="0"/>
     <ROW Component="TopoAlign.addin_1" ComponentId="{7FDB7459-0422-4A4F-A9D1-F0B7F189E0E4}" Directory_="__2_Dir" Attributes="0" KeyPath="TopoAlign.addin_1" Type="0"/>
+    <ROW Component="TopoAlign.addin_2" ComponentId="{BAB17FA2-F915-496E-A841-FC029BA906BD}" Directory_="__3_Dir" Attributes="0" KeyPath="TopoAlign.addin_2" Type="0"/>
     <ROW Component="TopoAlign.addin_3" ComponentId="{B872092F-97C2-4C5D-AB49-BB230EF112AA}" Directory_="__9_Dir" Attributes="0" KeyPath="TopoAlign.addin_3" Type="0"/>
     <ROW Component="TopoAlign.addin_4" ComponentId="{9E0D1BA2-A50C-4275-A894-862DF3C2085F}" Directory_="__10_Dir" Attributes="0" KeyPath="TopoAlign.addin_4" Type="0"/>
     <ROW Component="TopoAlign.addin_5" ComponentId="{25F23F17-7C77-4976-89D8-66CF440A4FE3}" Directory_="__Dir" Attributes="0" KeyPath="TopoAlign.addin_5" Type="0"/>
     <ROW Component="TopoAlign.addin_6" ComponentId="{D679B099-02E4-408A-A5E8-640FCDBDFAB3}" Directory_="__1_Dir" Attributes="0" KeyPath="TopoAlign.addin_6" Type="0"/>
     <ROW Component="TopoAlign.dll" ComponentId="{03F0D2B7-989A-4E14-A949-837CECE39A1C}" Directory_="NewFolder_Dir" Attributes="256" KeyPath="TopoAlign.dll"/>
     <ROW Component="TopoAlign.dll_1" ComponentId="{1388E731-46A2-4145-8EBD-B4E2F380255C}" Directory_="__2_Dir" Attributes="256" KeyPath="TopoAlign.dll_1"/>
+    <ROW Component="TopoAlign.dll_2" ComponentId="{0294F43B-6440-4C8A-A685-A8EF1BBFDF09}" Directory_="__3_Dir" Attributes="256" KeyPath="TopoAlign.dll_2"/>
     <ROW Component="TopoAlign.dll_3" ComponentId="{1ADB4904-EF19-43E6-9353-15C52CE9B51E}" Directory_="__9_Dir" Attributes="256" KeyPath="TopoAlign.dll_3"/>
     <ROW Component="TopoAlign.dll_4" ComponentId="{62E77137-EC43-4B22-B3C6-BFE0433085BB}" Directory_="__10_Dir" Attributes="256" KeyPath="TopoAlign.dll_4"/>
     <ROW Component="TopoAlign.dll_5" ComponentId="{75675335-46A9-4CBC-ACE3-78B0D7CDF67E}" Directory_="__Dir" Attributes="256" KeyPath="TopoAlign.dll_5"/>
@@ -76,6 +79,8 @@
     <ROW File="TopoAlign.addin_1" Component_="TopoAlign.addin_1" FileName="TOPOAL~1.ADD|TopoAlign.addin" Attributes="0" SourcePath="..\Bundle\RG tools Topo Align.bundle\Contents\2027\TopoAlign.addin" SelfReg="false"/>
     <ROW File="TopoAlign.deps.json_2" Component_="TopoAlign.addin_1" FileName="TOPOAL~1.JSO|TopoAlign.deps.json" Attributes="0" SourcePath="..\Bundle\RG tools Topo Align.bundle\Contents\2027\TopoAlign.deps.json" SelfReg="false"/>
     <ROW File="TopoAlign.dll_1" Component_="TopoAlign.dll_1" FileName="TOPOAL~1.DLL|TopoAlign.dll" Attributes="0" SourcePath="..\Bundle\RG tools Topo Align.bundle\Contents\2027\TopoAlign.dll" SelfReg="false"/>
+    <ROW File="TopoAlign.addin_2" Component_="TopoAlign.addin_2" FileName="TOPOAL~1.ADD|TopoAlign.addin" Attributes="0" SourcePath="..\Bundle\RG tools Topo Align.bundle\Contents\2021\TopoAlign.addin" SelfReg="false"/>
+    <ROW File="TopoAlign.dll_2" Component_="TopoAlign.dll_2" FileName="TOPOAL~1.DLL|TopoAlign.dll" Attributes="0" SourcePath="..\Bundle\RG tools Topo Align.bundle\Contents\2021\TopoAlign.dll" SelfReg="false"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.BootstrOptComponent">
     <ROW BootstrOptKey="GlobalOptions" DownloadFolder="[AppDataFolder][|Manufacturer]\[|ProductName]\prerequisites" Options="2"/>
@@ -181,6 +186,8 @@
     <ROW Feature_="MainFeature" Component_="TopoAlign.dll_6"/>
     <ROW Feature_="MainFeature" Component_="TopoAlign.addin_1"/>
     <ROW Feature_="MainFeature" Component_="TopoAlign.dll_1"/>
+    <ROW Feature_="MainFeature" Component_="TopoAlign.addin_2"/>
+    <ROW Feature_="MainFeature" Component_="TopoAlign.dll_2"/>
   </COMPONENT>
   <COMPONENT cid="caphyon.advinst.msicomp.MsiInstExSeqComponent">
     <ROW Action="AI_DOWNGRADE" Condition="AI_NEWERPRODUCTFOUND AND (UILevel &lt;&gt; 5)" Sequence="210"/>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # TopoAlign
 ![Revit Version](https://img.shields.io/badge/Revit%20Version-2022_--_2024-blue.svg) ![.NET](https://img.shields.io/badge/.NET-4.8-blue.svg) <br>
-![Revit Version](https://img.shields.io/badge/Revit%20Version-2025_--_2026-blue.svg) ![.NET](https://img.shields.io/badge/.NET-8-blue.svg) 
+![Revit Version](https://img.shields.io/badge/Revit%20Version-2025_--_2026-blue.svg) ![.NET](https://img.shields.io/badge/.NET-8-blue.svg) <br>
+![Revit Version](https://img.shields.io/badge/Revit%20Version-2027-blue.svg) ![.NET](https://img.shields.io/badge/.NET-10-blue.svg) 
 
 ![GitHub last commit](https://img.shields.io/github/last-commit/russgreen/topoalign) 
 

--- a/TopoAlign.slnx
+++ b/TopoAlign.slnx
@@ -1,11 +1,13 @@
 <Solution>
   <Configurations>
+    <BuildType Name="Debug R21" />
     <BuildType Name="Debug R22" />
     <BuildType Name="Debug R23" />
     <BuildType Name="Debug R24" />
     <BuildType Name="Debug R25" />
     <BuildType Name="Debug R26" />
     <BuildType Name="Debug R27" />
+    <BuildType Name="Release R21" />
     <BuildType Name="Release R22" />
     <BuildType Name="Release R23" />
     <BuildType Name="Release R24" />
@@ -19,12 +21,14 @@
     <File Path="README.md" />
   </Folder>
   <Project Path="build/_build.csproj">
+    <BuildType Solution="Debug R21|*" Project="Debug" />
     <BuildType Solution="Debug R22|*" Project="Debug" />
     <BuildType Solution="Debug R23|*" Project="Debug" />
     <BuildType Solution="Debug R24|*" Project="Debug" />
     <BuildType Solution="Debug R25|*" Project="Debug" />
     <BuildType Solution="Debug R26|*" Project="Debug" />
     <BuildType Solution="Debug R27|*" Project="Debug" />
+    <BuildType Solution="Release R21|*" Project="Release" />
     <BuildType Solution="Release R22|*" Project="Release" />
     <BuildType Solution="Release R23|*" Project="Release" />
     <BuildType Solution="Release R24|*" Project="Release" />

--- a/TopoAlign/TopoAlign.csproj
+++ b/TopoAlign/TopoAlign.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	  <Configurations>Debug R22;Debug R23;Debug R24;Debug R25;Debug R26;Debug R27</Configurations>
-	  <Configurations>$(Configurations);Release R22;Release R23;Release R24;Release R25;Release R26;Release R27</Configurations>
+	  <Configurations>Debug R21;Debug R22;Debug R23;Debug R24;Debug R25;Debug R26;Debug R27</Configurations>
+	  <Configurations>$(Configurations);Release R21;Release R22;Release R23;Release R24;Release R25;Release R26;Release R27</Configurations>
 	  <Description>Align topo surface to model elements</Description>
 	  <Copyright>Copyright © Russell Green</Copyright>
 	  <Version>2.7.0</Version>
@@ -32,6 +32,12 @@
 		<DefineConstants>$(DefineConstants);RELEASE</DefineConstants>		
 	</PropertyGroup>
 
+	<PropertyGroup Condition="$(Configuration.Contains('R21'))">
+		<TargetFramework>net48</TargetFramework>
+		<RevitVersion>2021</RevitVersion>
+		<DefineConstants>$(DefineConstants);REVIT2021</DefineConstants>
+		<DefineConstants>$(DefineConstants);REVIT2019_OR_GREATER;REVIT2020_OR_GREATER;REVIT2021_OR_GREATER</DefineConstants>
+	</PropertyGroup>
 	<PropertyGroup Condition="$(Configuration.Contains('R22'))">
 		<TargetFramework>net48</TargetFramework>
 		<RevitVersion>2022</RevitVersion>


### PR DESCRIPTION
#### PR Classification
New feature: adds support for Revit 2021 and updates documentation and installer configuration.

#### PR Summary
This pull request introduces support for Revit 2021, updates build configurations, and refreshes documentation and installer settings.
- TopoAlign.csproj: Added Debug/Release R21 configurations and property group for Revit 2021.
- TopoAlign.slnx: Added Debug/Release R21 build types and mapped them in the build project.
- TopoAlign.aip: Included new components, directories, and files for Revit 2021; bumped installer version to 23.6.
- README.md: Updated to reflect Revit 2021 and .NET 4.8 support, and clarified .NET versions for other Revit versions.
